### PR TITLE
Improve Clarity of Wallet Store Decoding Error Message

### DIFF
--- a/.changelog/unreleased/bug-fixes/2151-main.md
+++ b/.changelog/unreleased/bug-fixes/2151-main.md
@@ -1,0 +1,2 @@
+- Improve Clarity of Wallet Store Decoding Error Message
+  ([\#2151](https://github.com/anoma/namada/issues/2151))

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -17,7 +17,7 @@ use namada::types::key::*;
 use namada::types::token;
 use namada::types::uint::Uint;
 use namada::vm::validate_untrusted_wasm;
-use namada_sdk::wallet::{alias, Wallet};
+use namada_sdk::wallet::{alias, LoadStoreError, Wallet};
 use prost::bytes::Bytes;
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -265,12 +265,12 @@ pub async fn join_network(
     // Try to load pre-genesis wallet, if any
     let pre_genesis_wallet_path = base_dir.join(PRE_GENESIS_DIR);
     let pre_genesis_wallet =
-        if let Some(wallet) = crate::wallet::load(&pre_genesis_wallet_path) {
+        if let Ok(wallet) = crate::wallet::load(&pre_genesis_wallet_path) {
             Some(wallet)
         } else {
             validator_alias_and_dir
                 .as_ref()
-                .and_then(|(_, path)| crate::wallet::load(path))
+                .and_then(|(_, path)| crate::wallet::load(path).ok())
         };
 
     // Derive wallet from genesis
@@ -636,6 +636,7 @@ pub fn derive_genesis_addresses(
 ) {
     let maybe_pre_genesis_wallet =
         try_load_pre_genesis_wallet(&global_args.base_dir)
+            .ok()
             .map(|(wallet, _)| wallet);
     let contents =
         fs::read_to_string(&args.genesis_txs_path).unwrap_or_else(|err| {
@@ -923,7 +924,7 @@ pub fn init_genesis_validator(
 /// if it cannot be found.
 pub fn try_load_pre_genesis_wallet(
     base_dir: &Path,
-) -> Option<(Wallet<CliWalletUtils>, PathBuf)> {
+) -> Result<(Wallet<CliWalletUtils>, PathBuf), LoadStoreError> {
     let pre_genesis_dir = base_dir.join(PRE_GENESIS_DIR);
 
     crate::wallet::load(&pre_genesis_dir).map(|wallet| {
@@ -936,12 +937,17 @@ pub fn try_load_pre_genesis_wallet(
 pub fn load_pre_genesis_wallet_or_exit(
     base_dir: &Path,
 ) -> (Wallet<CliWalletUtils>, PathBuf) {
-    try_load_pre_genesis_wallet(base_dir).unwrap_or_else(|| {
-        eprintln!("No pre-genesis wallet found.",);
-        safe_exit(1)
-    })
+    match try_load_pre_genesis_wallet(base_dir) {
+        Ok(wallet) => {wallet}
+        Err(e) => {
+            eprintln!(
+                "Error loading the wallet:\n {}",
+                 e.to_string()
+             );
+            safe_exit(1)
+        }
+    }
 }
-
 async fn download_file(url: impl AsRef<str>) -> reqwest::Result<Bytes> {
     let url = url.as_ref();
     let response = reqwest::get(url).await?;

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -938,12 +938,9 @@ pub fn load_pre_genesis_wallet_or_exit(
     base_dir: &Path,
 ) -> (Wallet<CliWalletUtils>, PathBuf) {
     match try_load_pre_genesis_wallet(base_dir) {
-        Ok(wallet) => {wallet}
+        Ok(wallet) => wallet,
         Err(e) => {
-            eprintln!(
-                "Error loading the wallet:\n {}",
-                 e.to_string()
-             );
+            eprintln!("Error loading the wallet:\n {}", e.to_string());
             safe_exit(1)
         }
     }

--- a/apps/src/lib/wallet/mod.rs
+++ b/apps/src/lib/wallet/mod.rs
@@ -11,7 +11,10 @@ use namada::types::key::*;
 pub use namada_sdk::wallet::alias::Alias;
 use namada_sdk::wallet::fs::FsWalletStorage;
 use namada_sdk::wallet::store::Store;
-use namada_sdk::wallet::{ConfirmationResponse, FindKeyError, GenRestoreKeyError, LoadStoreError, Wallet, WalletIo};
+use namada_sdk::wallet::{
+    ConfirmationResponse, FindKeyError, GenRestoreKeyError, LoadStoreError,
+    Wallet, WalletIo,
+};
 pub use namada_sdk::wallet::{ValidatorData, ValidatorKeys};
 use rand_core::OsRng;
 pub use store::wallet_file;
@@ -240,7 +243,9 @@ pub fn save(wallet: &Wallet<CliWalletUtils>) -> std::io::Result<()> {
 }
 
 /// Load a wallet from the store file.
-pub fn load(store_dir: &Path) -> Result<Wallet<CliWalletUtils>, LoadStoreError> {
+pub fn load(
+    store_dir: &Path,
+) -> Result<Wallet<CliWalletUtils>, LoadStoreError> {
     let mut wallet = CliWalletUtils::new(store_dir.to_path_buf());
     wallet.load()?;
     Ok(wallet)

--- a/apps/src/lib/wallet/mod.rs
+++ b/apps/src/lib/wallet/mod.rs
@@ -11,9 +11,7 @@ use namada::types::key::*;
 pub use namada_sdk::wallet::alias::Alias;
 use namada_sdk::wallet::fs::FsWalletStorage;
 use namada_sdk::wallet::store::Store;
-use namada_sdk::wallet::{
-    ConfirmationResponse, FindKeyError, GenRestoreKeyError, Wallet, WalletIo,
-};
+use namada_sdk::wallet::{ConfirmationResponse, FindKeyError, GenRestoreKeyError, LoadStoreError, Wallet, WalletIo};
 pub use namada_sdk::wallet::{ValidatorData, ValidatorKeys};
 use rand_core::OsRng;
 pub use store::wallet_file;
@@ -242,12 +240,10 @@ pub fn save(wallet: &Wallet<CliWalletUtils>) -> std::io::Result<()> {
 }
 
 /// Load a wallet from the store file.
-pub fn load(store_dir: &Path) -> Option<Wallet<CliWalletUtils>> {
+pub fn load(store_dir: &Path) -> Result<Wallet<CliWalletUtils>, LoadStoreError> {
     let mut wallet = CliWalletUtils::new(store_dir.to_path_buf());
-    if wallet.load().is_err() {
-        return None;
-    }
-    Some(wallet)
+    wallet.load()?;
+    Ok(wallet)
 }
 
 /// Load a wallet from the store file or create a new wallet without any

--- a/tests/src/integration/setup.rs
+++ b/tests/src/integration/setup.rs
@@ -133,7 +133,7 @@ fn finalize_wallet(
         });
 
     // Try to load pre-genesis wallet
-    let pre_genesis_wallet = namada_apps::wallet::load(&pre_genesis_path);
+    let pre_genesis_wallet = namada_apps::wallet::load(&pre_genesis_path).ok();
     let chain_dir = global_args
         .base_dir
         .join(global_args.chain_id.as_ref().unwrap().as_str());


### PR DESCRIPTION
## Describe your changes
I modified https://github.com/nodersteam/namada/blob/456486fe61c2f5c3c60136963018224280b22f61/apps/src/lib/wallet/mod.rs#L245 to return a `Result` so the error can be propagated to the caller, and thus `eprinted` well.
## Indicate on which release or other PRs this topic is based on
Closes https://github.com/anoma/namada/issues/2151
## Checklist before merging to `draft`
- [x] I have added a changelog
- [X] Git history is in acceptable state
