### PR TITLE
 Add the ability for the Bridge pool VP to reject txs when the bridge is   disabled

### DIFF
--- a/.changelog/unreleased/bug-fixes/2027-v0.30.0.md
+++ b/.changelog/unreleased/bug-fixes/2027-v0.30.0.md
@@ -1,0 +1,2 @@
+- Add the ability for the Bridge pool VP to reject txs when the bridge is
+  disabled ([\#2027](https://github.com/anoma/namada/issues/2027))

--- a/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
@@ -21,8 +21,9 @@ use namada_core::hints;
 use namada_core::ledger::eth_bridge::storage::bridge_pool::{
     get_pending_key, is_bridge_pool_key, BRIDGE_POOL_ADDRESS,
 };
-use namada_core::ledger::eth_bridge::storage::whitelist;
+use namada_core::ledger::eth_bridge::storage::{active_key, whitelist};
 use namada_core::ledger::eth_bridge::ADDRESS as BRIDGE_ADDRESS;
+use namada_ethereum_bridge::storage::eth_bridge_queries::EthBridgeStatus;
 use namada_ethereum_bridge::storage::parameters::read_native_erc20_address;
 use namada_ethereum_bridge::storage::wrapped_erc20s;
 
@@ -537,6 +538,28 @@ where
             verifiers_len = _verifiers.len(),
             "Ethereum Bridge Pool VP triggered",
         );
+        {
+            let status: EthBridgeStatus = BorshDeserialize::try_from_slice(
+                self.ctx
+                    .storage
+                    .db
+                    .read_subspace_val(&active_key())
+                    .expect(
+                        "Reading the Ethereum bridge active key shouldn't \
+                         fail.",
+                    )
+                    .expect(
+                        "The Ethereum bridge active key should be in storage",
+                    )
+                    .as_slice(),
+            )
+            .expect(
+                "Deserializing the Ethereum bridge active key shouldn't fail.",
+            );
+            if matches!(status, EthBridgeStatus::Disabled) {
+                return Err(eyre!("Bridge closed").into());
+            }
+        }
         let Some(tx_data) = tx.data() else {
             return Err(eyre!("No transaction data found").into());
         };


### PR DESCRIPTION
## Describe your changes
I modified https://github.com/nodersteam/namada/blob/e84bb03324747819006f4eebd89fd57e7454c22c/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs#L529 to add a condition that checks the storage db if the bridge is closed
## Indicate on which release or other PRs this topic is based on
#2027
## Checklist before merging to `draft`
- [x] I have added a changelog
- [X] Git history is in acceptable state
